### PR TITLE
Fixes

### DIFF
--- a/client/Lykke.Service.PostProcessing.Contracts/Cqrs/Events/CashTransferProcessedEvent.cs
+++ b/client/Lykke.Service.PostProcessing.Contracts/Cqrs/Events/CashTransferProcessedEvent.cs
@@ -33,7 +33,7 @@ namespace Lykke.Service.PostProcessing.Contracts.Cqrs.Events
         [ProtoMember(8, IsRequired = false)]
         public decimal? FeeSize { get; set; }
 
-        [ProtoMember(7, IsRequired = true)]
+        [ProtoMember(9, IsRequired = true)]
         public Guid RequestId { get; set; }
     }
 }

--- a/src/Lykke.Service.PostProcessing/Modules/ServiceModule.cs
+++ b/src/Lykke.Service.PostProcessing/Modules/ServiceModule.cs
@@ -2,6 +2,9 @@
 using Lykke.Service.PostProcessing.RabbitSubscribers;
 using Lykke.Service.PostProcessing.Settings;
 using Lykke.SettingsReader;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Serialization;
 
 namespace Lykke.Service.PostProcessing.Modules
 {
@@ -21,6 +24,13 @@ namespace Lykke.Service.PostProcessing.Modules
                 .SingleInstance()
                 .WithParameter(TypedParameter.From(_appSettings.CurrentValue.PostProcessingService.MatchingEngineRabbit));
 
+            JsonConvert.DefaultSettings = (() =>
+            {
+                var settings = new JsonSerializerSettings();
+                settings.Converters.Add(new StringEnumConverter());
+                settings.ContractResolver = new CamelCasePropertyNamesContractResolver();
+                return settings;
+            });
         }
     }
 }

--- a/src/Lykke.Service.PostProcessing/RabbitSubscribers/MeRabbitSubscriber.cs
+++ b/src/Lykke.Service.PostProcessing/RabbitSubscribers/MeRabbitSubscriber.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using Autofac;
+﻿using Autofac;
 using Common;
 using JetBrains.Annotations;
 using Lykke.Common.Log;
@@ -15,6 +11,10 @@ using Lykke.Service.PostProcessing.Contracts.Cqrs.Events;
 using Lykke.Service.PostProcessing.Contracts.Cqrs.Models;
 using Lykke.Service.PostProcessing.Contracts.Cqrs.Models.Enums;
 using Lykke.Service.PostProcessing.Settings;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 using OrderType = Lykke.MatchingEngine.Connector.Models.Events.OrderType;
 
 namespace Lykke.Service.PostProcessing.RabbitSubscribers
@@ -34,7 +34,7 @@ namespace Lykke.Service.PostProcessing.RabbitSubscribers
         public MeRabbitSubscriber(
             [NotNull] ILogFactory logFactory,
             [NotNull] RabbitMqSettings rabbitMqSettings,
-            [NotNull] ICqrsEngine cqrsEngine, 
+            [NotNull] ICqrsEngine cqrsEngine,
             [NotNull] IDeduplicator deduplicator)
         {
             _logFactory = logFactory ?? throw new ArgumentNullException(nameof(logFactory));
@@ -100,7 +100,7 @@ namespace Lykke.Service.PostProcessing.RabbitSubscribers
                 {
                     OperationId = message.Header.MessageId,
                     OperationType = FeeOperationType.CashInOut,
-                    Fee = fees.ToJson()
+                    Fee = fees.Select(x => x.Transfer).ToJson()
                 };
                 _cqrsEngine.PublishEvent(feeEvent, BoundedContext.Name);
             }
@@ -130,7 +130,7 @@ namespace Lykke.Service.PostProcessing.RabbitSubscribers
                 {
                     OperationId = message.Header.MessageId,
                     OperationType = FeeOperationType.CashInOut,
-                    Fee = fees.ToJson()
+                    Fee = fees.Select(x => x.Transfer).ToJson()
                 };
                 _cqrsEngine.PublishEvent(feeEvent, BoundedContext.Name);
             }
@@ -162,7 +162,7 @@ namespace Lykke.Service.PostProcessing.RabbitSubscribers
                 {
                     OperationId = message.Header.MessageId,
                     OperationType = FeeOperationType.Transfer,
-                    Fee = fees.ToJson()
+                    Fee = fees.Select(x => x.Transfer).ToJson()
                 };
                 _cqrsEngine.PublishEvent(feeEvent, BoundedContext.Name);
             }

--- a/src/Lykke.Service.PostProcessing/RabbitSubscribers/MeRabbitSubscriber.cs
+++ b/src/Lykke.Service.PostProcessing/RabbitSubscribers/MeRabbitSubscriber.cs
@@ -100,7 +100,7 @@ namespace Lykke.Service.PostProcessing.RabbitSubscribers
                 {
                     OperationId = message.Header.MessageId,
                     OperationType = FeeOperationType.CashInOut,
-                    Fee = fees.Select(x => x.Transfer).ToJson()
+                    Fee = fees.Where(x => x.Transfer != null).Select(x => x.Transfer).ToJson()
                 };
                 _cqrsEngine.PublishEvent(feeEvent, BoundedContext.Name);
             }
@@ -130,7 +130,7 @@ namespace Lykke.Service.PostProcessing.RabbitSubscribers
                 {
                     OperationId = message.Header.MessageId,
                     OperationType = FeeOperationType.CashInOut,
-                    Fee = fees.Select(x => x.Transfer).ToJson()
+                    Fee = fees.Where(x => x.Transfer != null).Select(x => x.Transfer).ToJson()
                 };
                 _cqrsEngine.PublishEvent(feeEvent, BoundedContext.Name);
             }
@@ -162,7 +162,7 @@ namespace Lykke.Service.PostProcessing.RabbitSubscribers
                 {
                     OperationId = message.Header.MessageId,
                     OperationType = FeeOperationType.Transfer,
-                    Fee = fees.Select(x => x.Transfer).ToJson()
+                    Fee = fees.Where(x => x.Transfer != null).Select(x => x.Transfer).ToJson()
                 };
                 _cqrsEngine.PublishEvent(feeEvent, BoundedContext.Name);
             }


### PR DESCRIPTION
https://lykkex.atlassian.net/browse/LWDEV-9050
https://lykkex.atlassian.net/browse/LWDEV-9051

- Bugfix: CashTransferProcessedEvent serialization
- Changed FeeChargedEvent.Fee content. It is now 'Transfer'-only info; and it is serialized using StringEnumConverter and CamelCasePropertyNamesContractResolver.